### PR TITLE
Laravel 10 + PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.0, 8.1, 8.2 ]
+        php: [ 8.1, 8.2 ]
         laravel: [ 9.*, 10.* ]
         include:
           - laravel: 9.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       -   name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
       -   name: Cache dependencies
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.composer/cache/files
             key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,11 +8,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.0, 8.1 ]
-        laravel: [ 9.* ]
+        php: [ 8.0, 8.1, 8.2 ]
+        laravel: [ 9.*, 10.* ]
         include:
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "illuminate/filesystem": "^9.0|^10.0",
         "illuminate/mail": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/filesystem": "^9.0",
-        "illuminate/mail": "^9.0",
-        "illuminate/support": "^9.0",
+        "illuminate/filesystem": "^9.0|^10.0",
+        "illuminate/mail": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
         "nesbot/carbon": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0"
+        "orchestra/testbench": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" beStrictAboutTestsThatDoNotTestAnything="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory suffix=".php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Hi @clemblanco @fridzema ,

I am looking to upgrade an application which is using this package to Laravel 10, in summary I have made the following changes:

- Dropped PHP 8.0 support, now PHP ^8.1.
- Laravel 9 & 10 Support (feel free to drop the L9 support if you wish).
- GitHub Actions workflow updated for Laravel 10 + PHP 8.1, updated action versions to remove deprecation warnings.
- phpunit.xml file migrated to newer configuration and update path to tests

This should probably go into a version 3.0.0 release.

Cheers!