### PR TITLE
Laravel 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.2 ]
         laravel: [ 9.*, 10.*, 11.* ]
         include:
           - laravel: 9.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,14 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 8.1, 8.2 ]
-        laravel: [ 9.*, 10.* ]
+        laravel: [ 9.*, 10.*, 11.* ]
         include:
           - laravel: 9.*
             testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This can be useful when wanting to store emails sent for archive purposes.
 
 You can install the package via composer:
 
-For Laravel 9.x and 10.x
+For Laravel 9.x, 10.x, 11.x
 
 ```bash
 composer require pod-point/laravel-mail-export

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This can be useful when wanting to store emails sent for archive purposes.
 
 You can install the package via composer:
 
-For Laravel 9.x, 10.x, 11.x
+For Laravel 9.x, 10.x, 11.x (requires PHP version 8.2 or higher)
 
 ```bash
 composer require pod-point/laravel-mail-export

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/filesystem": "^9.0|^10.0",
-        "illuminate/mail": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
+        "php": "^8.2",
+        "illuminate/filesystem": "^9.0|^10.0|^11.0",
+        "illuminate/mail": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0",
         "nesbot/carbon": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0|^8.0"
+        "orchestra/testbench": "^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi @clemblanco 

Please see this PR for Laravel 11 support with PHP 8.2 as minimum version now.

I am hoping you can review and merge this in.